### PR TITLE
Implement AvgPrice NPP acceleration and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ set(CMAKE_C_STANDARD 11)
 option(BUILD_DEV_TOOLS "Build development tools (gen_code, ta_regtest)" ON)
 message(STATUS "BUILD_DEV_TOOLS: ${BUILD_DEV_TOOLS}")
 
+option(USE_NPP "Enable NVIDIA Performance Primitives" OFF)
+message(STATUS "USE_NPP: ${USE_NPP}")
+if(USE_NPP)
+    find_package(CUDAToolkit)
+    if(NOT CUDAToolkit_FOUND)
+        message(WARNING "CUDA toolkit not found - disabling NPP")
+        set(USE_NPP OFF)
+    endif()
+endif()
+
 # Default to Release config
 if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
@@ -234,9 +244,9 @@ set(LIB_SOURCES
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_CDLUNIQUE3RIVER.c"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_CDLRISEFALL3METHODS.c"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_CDLLADDERBOTTOM.c"
-	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_PLUS_DM.c"
-	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_ADD.c"
-	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_STOCHRSI.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_PLUS_DM.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_ADD.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_STOCHRSI.c"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_CDLHANGINGMAN.c"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_NVI.c"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_T3.c"
@@ -374,12 +384,41 @@ set(LIB_SOURCES
 
 list(APPEND LIB_SOURCES ${COMMON_SOURCES})
 list(APPEND LIB_SOURCES ${IDL_SOURCES})
+if(USE_NPP)
+    list(APPEND LIB_SOURCES
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_ADD_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_DIV_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_MULT_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_SUB_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_SUM_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_AVGPRICE_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_SMA_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_SQRT_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_ACOS_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_ASIN_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_ATAN_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_CEIL_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_COS_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_COSH_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_EXP_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_FLOOR_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_LN_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_LOG10_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_SIN_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_SINH_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_TAN_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_TANH_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_MIN_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_MAX_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_CORREL_NPP.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ta_func/ta_LINEARREG_SLOPE_NPP.c")
+endif()
 
 add_library(ta-lib SHARED ${LIB_SOURCES})
 set_target_properties(ta-lib PROPERTIES
-	SOVERSION ${PROJECT_VERSION}
-	DEFINE_SYMBOL TA_LIB_SHARED
-	OUTPUT_NAME "ta-lib"
+        SOVERSION ${PROJECT_VERSION}
+        DEFINE_SYMBOL TA_LIB_SHARED
+        OUTPUT_NAME "ta-lib"
 )
 add_library(ta-lib-static STATIC ${LIB_SOURCES})
 
@@ -391,6 +430,11 @@ if(WIN32)
 	# Note: WIN32 is defined regardless of 32 or 64 bits host.
 	set_target_properties(ta-lib-static PROPERTIES OUTPUT_NAME ta-lib-static)
 endif(WIN32)
+
+if(USE_NPP AND TARGET CUDA::npps)
+    target_link_libraries(ta-lib PRIVATE CUDA::npps CUDA::nppc)
+    target_link_libraries(ta-lib-static PRIVATE CUDA::npps CUDA::nppc)
+endif()
 
 if(MSVC)
 	add_compile_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:/deterministic>)

--- a/README_NPP.md
+++ b/README_NPP.md
@@ -1,0 +1,40 @@
+# NVIDIA Performance Primitives (NPP) Acceleration
+
+This fork of TA‑Lib adds optional GPU acceleration via [NVIDIA Performance Primitives](https://developer.nvidia.com/npp). When enabled, many vector math functions use NPP to process data on the GPU, while preserving the original API.
+
+## Enabling NPP support
+
+1. Install the CUDA Toolkit which provides the NPP libraries.
+2. Configure the build with `USE_NPP=ON`:
+
+```bash
+cmake -S . -B build -DUSE_NPP=ON
+cmake --build build -j$(nproc)
+```
+
+If the CUDA Toolkit cannot be found, the build system automatically disables NPP and falls back to the CPU implementation.
+
+## Accelerated functions
+
+When compiled with `USE_NPP`, the following core routines call their GPU implementations automatically:
+
+- `TA_ADD`, `TA_SUB`, `TA_MULT`, `TA_DIV`
+- `TA_SUM`, `TA_SMA`, `TA_SQRT`, `TA_AVGPRICE`
+- `TA_MIN`, `TA_MAX`, `TA_CORREL`, `TA_LINEARREG_SLOPE`
+- Trigonometric and exponential transforms such as `TA_SIN`, `TA_COS`, `TA_TAN`, `TA_EXP`, `TA_LN`, `TA_LOG10`, `TA_ACOS`, `TA_ASIN`, `TA_ATAN`, `TA_CEIL`, `TA_FLOOR`, `TA_SINH`, `TA_COSH`, `TA_TANH`
+
+The same C APIs are used. For example, calling `TA_SMA` with NPP enabled executes the GPU‑accelerated version; no source changes are needed in user code.
+
+For advanced usage, NPP-specific entry points like `TA_ADD_NPP` are declared in `ta_func.h`. These functions perform no parameter checking and assume valid indices.
+
+## Example
+
+```c
+#include <ta_func.h>
+
+/* build with -DUSE_NPP=ON */
+TA_RetCode ret = TA_SMA(0, length-1, prices, 14, &beg, &nb, output);
+```
+
+This call uses `nppsSum` internally when NPP is available and falls back to the original CPU implementation otherwise.
+

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,21 @@ AM_PROG_AR
 AC_PROG_CC
 LT_INIT
 
+# Option to enable NVIDIA Performance Primitives
+AC_ARG_ENABLE([npp],
+    AS_HELP_STRING([--enable-npp], [Enable NVIDIA Performance Primitives]),
+    [use_npp=$enableval], [use_npp=no])
+AM_CONDITIONAL([USE_NPP], [test "x$use_npp" = "xyes"])
+if test "x$use_npp" = "xyes"; then
+    AC_DEFINE([USE_NPP], [1], [Define to 1 to enable NPP acceleration])
+    AC_CHECK_LIB([npps], [nppsAdd_64f],
+        [NPP_LIBS="-lnpps -lnppc"],
+        [AC_MSG_ERROR([npps library not found])])
+else
+    NPP_LIBS=""
+fi
+AC_SUBST([NPP_LIBS])
+
 # Autoupdate added the next two lines to ensure that your configure
 # script's behavior did not change.  They are probably safe to remove.
 AC_CHECK_INCLUDES_DEFAULT

--- a/include/ta_func.h
+++ b/include/ta_func.h
@@ -170,6 +170,400 @@ TA_LIB_API TA_RetCode TA_S_ADD( int    startIdx,
                                            int          *outNBElement,
                                            double        outReal[] );
 
+#ifdef USE_NPP
+TA_LIB_API TA_RetCode TA_ADD_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal0[],
+                                  const double inReal1[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_ADD_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal0[],
+                                    const float  inReal1[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_DIV_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal0[],
+                                  const double inReal1[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_DIV_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal0[],
+                                    const float  inReal1[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_MULT_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal0[],
+                                   const double inReal1[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_MULT_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal0[],
+                                     const float  inReal1[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_SUB_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal0[],
+                                  const double inReal1[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_SUB_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal0[],
+                                    const float  inReal1[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_SUM_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int           optInTimePeriod,
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_SUM_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int           optInTimePeriod,
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_SMA_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int           optInTimePeriod,
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_SMA_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int           optInTimePeriod,
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_SQRT_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_SQRT_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_AVGPRICE_NPP( int    startIdx,
+                                       int    endIdx,
+                                       const double inOpen[],
+                                       const double inHigh[],
+                                       const double inLow[],
+                                       const double inClose[],
+                                       int          *outBegIdx,
+                                       int          *outNBElement,
+                                       double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_AVGPRICE_NPP( int    startIdx,
+                                         int    endIdx,
+                                         const float  inOpen[],
+                                         const float  inHigh[],
+                                         const float  inLow[],
+                                         const float  inClose[],
+                                         int          *outBegIdx,
+                                         int          *outNBElement,
+                                         double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_ACOS_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_ACOS_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_ASIN_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_ASIN_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_ATAN_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_ATAN_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_CEIL_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_CEIL_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_COS_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_COS_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_COSH_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_COSH_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_EXP_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_EXP_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_FLOOR_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const double inReal[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_FLOOR_NPP( int    startIdx,
+                                      int    endIdx,
+                                      const float  inReal[],
+                                      int          *outBegIdx,
+                                      int          *outNBElement,
+                                      double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_LN_NPP( int    startIdx,
+                                 int    endIdx,
+                                 const double inReal[],
+                                 int          *outBegIdx,
+                                 int          *outNBElement,
+                                 double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_LN_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const float  inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_LOG10_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const double inReal[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_LOG10_NPP( int    startIdx,
+                                      int    endIdx,
+                                      const float  inReal[],
+                                      int          *outBegIdx,
+                                      int          *outNBElement,
+                                      double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_SIN_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_SIN_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_SINH_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_SINH_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_TAN_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_TAN_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_TANH_NPP( int    startIdx,
+                                   int    endIdx,
+                                   const double inReal[],
+                                   int          *outBegIdx,
+                                   int          *outNBElement,
+                                   double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_TANH_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const float  inReal[],
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_MIN_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int           optInTimePeriod,
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_MIN_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int           optInTimePeriod,
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_MAX_NPP( int    startIdx,
+                                  int    endIdx,
+                                  const double inReal[],
+                                  int           optInTimePeriod,
+                                  int          *outBegIdx,
+                                  int          *outNBElement,
+                                  double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_MAX_NPP( int    startIdx,
+                                    int    endIdx,
+                                    const float  inReal[],
+                                    int           optInTimePeriod,
+                                    int          *outBegIdx,
+                                    int          *outNBElement,
+                                    double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_CORREL_NPP( int    startIdx,
+                                     int    endIdx,
+                                     const double inReal0[],
+                                     const double inReal1[],
+                                     int           optInTimePeriod,
+                                     int          *outBegIdx,
+                                     int          *outNBElement,
+                                     double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_CORREL_NPP( int    startIdx,
+                                       int    endIdx,
+                                       const float  inReal0[],
+                                       const float  inReal1[],
+                                       int           optInTimePeriod,
+                                       int          *outBegIdx,
+                                       int          *outNBElement,
+                                       double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_LINEARREG_SLOPE_NPP( int    startIdx,
+                                              int    endIdx,
+                                              const double inReal[],
+                                              int           optInTimePeriod,
+                                              int          *outBegIdx,
+                                              int          *outNBElement,
+                                              double        outReal[] );
+
+TA_LIB_API TA_RetCode TA_S_LINEARREG_SLOPE_NPP( int    startIdx,
+                                                int    endIdx,
+                                                const float  inReal[],
+                                                int           optInTimePeriod,
+                                                int          *outBegIdx,
+                                                int          *outNBElement,
+                                                double        outReal[] );
+#endif
+
 TA_LIB_API int TA_ADD_Lookback( void );
 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,5 +8,6 @@ libta_lib_la_SOURCES =
 libta_lib_la_LIBADD = \
   ta_abstract/libta_abstract.la \
   ta_func/libta_func.la \
-  ta_common/libta_common.la
+  ta_common/libta_common.la \
+  @NPP_LIBS@
 

--- a/src/ta_func/Makefile.am
+++ b/src/ta_func/Makefile.am
@@ -3,12 +3,12 @@ noinst_LTLIBRARIES = libta_func.la
 AM_CPPFLAGS = -I../ta_common/
 
 libta_func_la_SOURCES = ta_utility.c \
-	ta_ACCBANDS.c \
-	ta_ACOS.c \
-	ta_AD.c \
-	ta_ADD.c \
-	ta_ADOSC.c \
-	ta_ADX.c \
+        ta_ACCBANDS.c \
+        ta_ACOS.c \
+        ta_AD.c \
+       ta_ADD.c \
+       ta_ADOSC.c \
+        ta_ADX.c \
 	ta_ADXR.c \
 	ta_APO.c \
 	ta_AROON.c \
@@ -20,7 +20,7 @@ libta_func_la_SOURCES = ta_utility.c \
 	ta_AVGDEV.c \
 	ta_BBANDS.c \
 	ta_BETA.c \
-	ta_BOP.c \
+        ta_BOP.c \
 	ta_CCI.c \
 	ta_CDL2CROWS.c \
 	ta_CDL3BLACKCROWS.c \
@@ -161,9 +161,39 @@ libta_func_la_SOURCES = ta_utility.c \
 	ta_TYPPRICE.c \
 	ta_ULTOSC.c \
 	ta_VAR.c \
-	ta_WCLPRICE.c \
-	ta_WILLR.c \
-	ta_WMA.c
+        ta_WCLPRICE.c \
+        ta_WILLR.c \
+        ta_WMA.c
+
+if USE_NPP
+libta_func_la_SOURCES += \
+        ta_ADD_NPP.c \
+        ta_DIV_NPP.c \
+        ta_MULT_NPP.c \
+        ta_SUB_NPP.c \
+        ta_SUM_NPP.c \
+        ta_AVGPRICE_NPP.c \
+        ta_SMA_NPP.c \
+        ta_SQRT_NPP.c \
+        ta_ACOS_NPP.c \
+        ta_ASIN_NPP.c \
+        ta_ATAN_NPP.c \
+        ta_CEIL_NPP.c \
+        ta_COS_NPP.c \
+        ta_COSH_NPP.c \
+        ta_EXP_NPP.c \
+        ta_FLOOR_NPP.c \
+        ta_LN_NPP.c \
+        ta_LOG10_NPP.c \
+        ta_SIN_NPP.c \
+        ta_SINH_NPP.c \
+        ta_TAN_NPP.c \
+        ta_TANH_NPP.c \
+        ta_MIN_NPP.c \
+        ta_MAX_NPP.c \
+        ta_CORREL_NPP.c \
+        ta_LINEARREG_SLOPE_NPP.c
+endif
 
 libta_funcdir=$(includedir)/ta-lib/
 libta_func_HEADERS = ../../include/ta_defs.h \

--- a/src/ta_func/ta_ACOS.c
+++ b/src/ta_func/ta_ACOS.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_ACOS_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_ACOS_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_acos(inReal[i]);

--- a/src/ta_func/ta_ACOS_NPP.c
+++ b/src/ta_func/ta_ACOS_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for ACOS */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_ACOS_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsAcos_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_ACOS_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsAcos_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_ADD.c
+++ b/src/ta_func/ta_ADD.c
@@ -190,6 +190,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_ADD_NPP(startIdx, endIdx, inReal0, inReal1,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -268,6 +272,10 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+   return TA_S_ADD_NPP(startIdx, endIdx, inReal0, inReal1,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */      outReal[outIdx] = inReal0[i]+inReal1[i];

--- a/src/ta_func/ta_ADD_NPP.c
+++ b/src/ta_func/ta_ADD_NPP.c
@@ -1,0 +1,58 @@
+/* TA-LIB - NPP accelerated implementation for ADD */
+
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_ADD_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal0[],
+                       const double inReal1[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsAdd_64f((Npp64f*)&inReal0[startIdx],
+                              (Npp64f*)&inReal1[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_ADD_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal0[],
+                         const float inReal1[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsAdd_32f((Npp32f*)&inReal0[startIdx],
+                              (Npp32f*)&inReal1[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_ASIN.c
+++ b/src/ta_func/ta_ASIN.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_ASIN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
       outReal[outIdx] = std_asin(inReal[i]);
@@ -256,6 +260,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_ASIN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_asin(inReal[i]);

--- a/src/ta_func/ta_ASIN_NPP.c
+++ b/src/ta_func/ta_ASIN_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for ASIN */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_ASIN_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsAsin_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_ASIN_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsAsin_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_ATAN.c
+++ b/src/ta_func/ta_ATAN.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_ATAN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    /* Default return values */
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
@@ -258,6 +262,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_ATAN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_atan(inReal[i]);

--- a/src/ta_func/ta_ATAN_NPP.c
+++ b/src/ta_func/ta_ATAN_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for ATAN */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_ATAN_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsArctan_64f((Npp64f*)&inReal[startIdx],
+                                 (Npp64f*)outReal,
+                                 length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_ATAN_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsArctan_32f((Npp32f*)&inReal[startIdx],
+                                 (Npp32f*)outReal,
+                                 length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_AVGPRICE.c
+++ b/src/ta_func/ta_AVGPRICE.c
@@ -204,6 +204,10 @@ double outReal[],
    /* Insert TA function code here. */
 
    /* Average price = (High + Low + Open + Close) / 4 */
+#ifdef USE_NPP
+   return TA_AVGPRICE_NPP(startIdx, endIdx, inOpen, inHigh, inLow, inClose,
+                          outBegIdx, outNBElement, outReal);
+#endif
 
    outIdx = 0;
 
@@ -293,8 +297,12 @@ double outReal[],
 /* Generated */        return ENUM_VALUE(RetCode,TA_BAD_PARAM,BadParam);
 /* Generated */     #endif 
 /* Generated */  #endif
-/* Generated */  #endif 
+/* Generated */  #endif
 /* Generated */    outIdx = 0;
+/* Generated */ #ifdef USE_NPP
+/* Generated */    return TA_S_AVGPRICE_NPP(startIdx, endIdx, inOpen, inHigh, inLow, inClose,
+/* Generated */                             outBegIdx, outNBElement, outReal);
+/* Generated */ #endif
 /* Generated */    for( i=startIdx; i <= endIdx; i++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx++] = ( inHigh [i] +

--- a/src/ta_func/ta_AVGPRICE_NPP.c
+++ b/src/ta_func/ta_AVGPRICE_NPP.c
@@ -1,0 +1,79 @@
+/* NPP accelerated implementation for AVGPRICE */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_AVGPRICE_NPP( int startIdx,
+                            int endIdx,
+                            const double inOpen[],
+                            const double inHigh[],
+                            const double inLow[],
+                            const double inClose[],
+                            int *outBegIdx,
+                            int *outNBElement,
+                            double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    int length = endIdx - startIdx + 1;
+    NppStatus s;
+    /* outReal = inOpen + inHigh */
+    s = nppsAdd_64f((Npp64f*)&inOpen[startIdx], (Npp64f*)&inHigh[startIdx], (Npp64f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    /* outReal += inLow */
+    s = nppsAdd_64f_I((Npp64f*)&inLow[startIdx], (Npp64f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    /* outReal += inClose */
+    s = nppsAdd_64f_I((Npp64f*)&inClose[startIdx], (Npp64f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    /* outReal /= 4 */
+    s = nppsMulC_64f_I(0.25, (Npp64f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_AVGPRICE_NPP( int startIdx,
+                              int endIdx,
+                              const float inOpen[],
+                              const float inHigh[],
+                              const float inLow[],
+                              const float inClose[],
+                              int *outBegIdx,
+                              int *outNBElement,
+                              double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    int length = endIdx - startIdx + 1;
+    NppStatus s;
+    s = nppsAdd_32f((Npp32f*)&inOpen[startIdx], (Npp32f*)&inHigh[startIdx], (Npp32f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    s = nppsAdd_32f_I((Npp32f*)&inLow[startIdx], (Npp32f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    s = nppsAdd_32f_I((Npp32f*)&inClose[startIdx], (Npp32f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    s = nppsMulC_32f_I(0.25f, (Npp32f*)outReal, length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_CEIL.c
+++ b/src/ta_func/ta_CEIL.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_CEIL_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_CEIL_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_ceil(inReal[i]);

--- a/src/ta_func/ta_CEIL_NPP.c
+++ b/src/ta_func/ta_CEIL_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for CEIL */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_CEIL_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsCeil_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_CEIL_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsCeil_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_CORREL.c
+++ b/src/ta_func/ta_CORREL.c
@@ -218,6 +218,11 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_CORREL_NPP(startIdx, endIdx, inReal0, inReal1,
+                        optInTimePeriod, outBegIdx, outNBElement,
+                        outReal);
+#endif
 
    /* Move up the start index if there is not
     * enough initial data.
@@ -354,6 +359,11 @@ double outReal[],
 /* Generated */                         double        outReal[] )
 /* Generated */ #endif
 /* Generated */ {
+#ifdef USE_NPP
+   return TA_S_CORREL_NPP(startIdx, endIdx, inReal0, inReal1,
+                          optInTimePeriod, outBegIdx, outNBElement,
+                          outReal);
+#endif
 /* Generated */     double sumXY, sumX, sumY, sumX2, sumY2, x, y, trailingX, trailingY;
 /* Generated */     double tempReal;
 /* Generated */     int lookbackTotal, today, trailingIdx, outIdx;

--- a/src/ta_func/ta_CORREL_NPP.c
+++ b/src/ta_func/ta_CORREL_NPP.c
@@ -1,0 +1,119 @@
+/* NPP accelerated implementation for CORREL */
+#include "ta_func.h"
+#include "ta_memory.h"
+#include <npps.h>
+#include <math.h>
+
+TA_RetCode TA_CORREL_NPP( int startIdx,
+                          int endIdx,
+                          const double inReal0[],
+                          const double inReal1[],
+                          int optInTimePeriod,
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 1 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        const double *xPtr = &inReal0[idx + startIdx - lookbackTotal];
+        const double *yPtr = &inReal1[idx + startIdx - lookbackTotal];
+        Npp64f sumX, sumY, sumXY, sumX2, sumY2;
+        NppStatus s;
+        s = nppsSum_64f((Npp64f*)xPtr, optInTimePeriod, &sumX);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsSum_64f((Npp64f*)yPtr, optInTimePeriod, &sumY);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsDotProd_64f((Npp64f*)xPtr, (Npp64f*)yPtr, optInTimePeriod, &sumXY);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsDotProd_64f((Npp64f*)xPtr, (Npp64f*)xPtr, optInTimePeriod, &sumX2);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsDotProd_64f((Npp64f*)yPtr, (Npp64f*)yPtr, optInTimePeriod, &sumY2);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        double numerator = sumXY - (sumX * sumY) / optInTimePeriod;
+        double denom = (sumX2 - (sumX * sumX) / optInTimePeriod) *
+                       (sumY2 - (sumY * sumY) / optInTimePeriod);
+        if( denom <= 0.0 )
+            outReal[idx] = 0.0;
+        else
+            outReal[idx] = numerator / sqrt(denom);
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_CORREL_NPP( int startIdx,
+                            int endIdx,
+                            const float inReal0[],
+                            const float inReal1[],
+                            int optInTimePeriod,
+                            int *outBegIdx,
+                            int *outNBElement,
+                            double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 1 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        const float *xPtr = &inReal0[idx + startIdx - lookbackTotal];
+        const float *yPtr = &inReal1[idx + startIdx - lookbackTotal];
+        Npp32f sumX, sumY, sumXY, sumX2, sumY2;
+        NppStatus s;
+        s = nppsSum_32f((Npp32f*)xPtr, optInTimePeriod, &sumX);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsSum_32f((Npp32f*)yPtr, optInTimePeriod, &sumY);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsDotProd_32f((Npp32f*)xPtr, (Npp32f*)yPtr, optInTimePeriod, &sumXY);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsDotProd_32f((Npp32f*)xPtr, (Npp32f*)xPtr, optInTimePeriod, &sumX2);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        s = nppsDotProd_32f((Npp32f*)yPtr, (Npp32f*)yPtr, optInTimePeriod, &sumY2);
+        if( s != NPP_SUCCESS ) return TA_INTERNAL_ERROR(0);
+        double numerator = sumXY - (sumX * sumY) / optInTimePeriod;
+        double denom = (sumX2 - (sumX * sumX) / optInTimePeriod) *
+                       (sumY2 - (sumY * sumY) / optInTimePeriod);
+        if( denom <= 0.0 )
+            outReal[idx] = 0.0;
+        else
+            outReal[idx] = numerator / sqrt(denom);
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_COS.c
+++ b/src/ta_func/ta_COS.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_COS_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_COS_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_cos(inReal[i]);

--- a/src/ta_func/ta_COSH.c
+++ b/src/ta_func/ta_COSH.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_COSH_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_COSH_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_cosh(inReal[i]);

--- a/src/ta_func/ta_COSH_NPP.c
+++ b/src/ta_func/ta_COSH_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for COSH */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_COSH_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsCosh_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_COSH_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsCosh_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_COS_NPP.c
+++ b/src/ta_func/ta_COS_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for COS */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_COS_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsCos_64f((Npp64f*)&inReal[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_COS_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsCos_32f((Npp32f*)&inReal[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_DIV.c
+++ b/src/ta_func/ta_DIV.c
@@ -190,6 +190,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_DIV_NPP(startIdx, endIdx, inReal0, inReal1,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -268,6 +272,10 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+   return TA_S_DIV_NPP(startIdx, endIdx, inReal0, inReal1,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = inReal0[i]/inReal1[i];

--- a/src/ta_func/ta_DIV_NPP.c
+++ b/src/ta_func/ta_DIV_NPP.c
@@ -1,0 +1,57 @@
+/* NPP accelerated implementation for DIV */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_DIV_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal0[],
+                       const double inReal1[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsDiv_64f((Npp64f*)&inReal0[startIdx],
+                              (Npp64f*)&inReal1[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_DIV_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal0[],
+                         const float inReal1[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsDiv_32f((Npp32f*)&inReal0[startIdx],
+                              (Npp32f*)&inReal1[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_EXP.c
+++ b/src/ta_func/ta_EXP.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_EXP_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_EXP_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_exp(inReal[i]);

--- a/src/ta_func/ta_EXP_NPP.c
+++ b/src/ta_func/ta_EXP_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for EXP */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_EXP_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsExp_64f((Npp64f*)&inReal[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_EXP_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsExp_32f((Npp32f*)&inReal[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_FLOOR.c
+++ b/src/ta_func/ta_FLOOR.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_FLOOR_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_FLOOR_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_floor(inReal[i]);

--- a/src/ta_func/ta_FLOOR_NPP.c
+++ b/src/ta_func/ta_FLOOR_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for FLOOR */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_FLOOR_NPP( int startIdx,
+                         int endIdx,
+                         const double inReal[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsFloor_64f((Npp64f*)&inReal[startIdx],
+                                (Npp64f*)outReal,
+                                length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_FLOOR_NPP( int startIdx,
+                           int endIdx,
+                           const float inReal[],
+                           int *outBegIdx,
+                           int *outNBElement,
+                           double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsFloor_32f((Npp32f*)&inReal[startIdx],
+                                (Npp32f*)outReal,
+                                length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_LINEARREG_SLOPE.c
+++ b/src/ta_func/ta_LINEARREG_SLOPE.c
@@ -215,6 +215,11 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_LINEARREG_SLOPE_NPP(startIdx, endIdx, inReal,
+                                 optInTimePeriod, outBegIdx,
+                                 outNBElement, outReal);
+#endif
 
    /* Linear Regression is a concept also known as the
     * "least squares method" or "best fit." Linear
@@ -320,6 +325,11 @@ double outReal[],
 /* Generated */                                  double        outReal[] )
 /* Generated */ #endif
 /* Generated */ {
+#ifdef USE_NPP
+   return TA_S_LINEARREG_SLOPE_NPP(startIdx, endIdx, inReal,
+                                   optInTimePeriod, outBegIdx,
+                                   outNBElement, outReal);
+#endif
 /* Generated */    int outIdx;
 /* Generated */    int today, lookbackTotal;
 /* Generated */    double SumX, SumXY, SumY, SumXSqr, Divisor;

--- a/src/ta_func/ta_LINEARREG_SLOPE_NPP.c
+++ b/src/ta_func/ta_LINEARREG_SLOPE_NPP.c
@@ -1,0 +1,110 @@
+/* NPP accelerated implementation for LINEARREG_SLOPE */
+#include "ta_func.h"
+#include "ta_memory.h"
+#include <npps.h>
+
+TA_RetCode TA_LINEARREG_SLOPE_NPP( int startIdx,
+                                   int endIdx,
+                                   const double inReal[],
+                                   int optInTimePeriod,
+                                   int *outBegIdx,
+                                   int *outNBElement,
+                                   double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 14;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    double *weights = TA_Malloc(sizeof(double)*optInTimePeriod);
+    if(!weights) return TA_ALLOC_ERR;
+    for(int i=0;i<optInTimePeriod;i++)
+        weights[i] = i;
+
+    double SumX = optInTimePeriod * (optInTimePeriod - 1) * 0.5;
+    double SumXSqr = optInTimePeriod * (optInTimePeriod - 1) * (2 * optInTimePeriod - 1) / 6.0;
+    double Divisor = SumX * SumX - optInTimePeriod * SumXSqr;
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        const double *data = &inReal[idx + startIdx - lookbackTotal];
+        Npp64f sumY, sumXY;
+        NppStatus s = nppsSum_64f((Npp64f*)data, optInTimePeriod, &sumY);
+        if( s != NPP_SUCCESS ){ TA_Free(weights); return TA_INTERNAL_ERROR(0); }
+        s = nppsDotProd_64f((Npp64f*)weights, (Npp64f*)data, optInTimePeriod, &sumXY);
+        if( s != NPP_SUCCESS ){ TA_Free(weights); return TA_INTERNAL_ERROR(0); }
+        outReal[idx] = ( optInTimePeriod * sumXY - SumX * sumY) / Divisor;
+    }
+
+    TA_Free(weights);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_LINEARREG_SLOPE_NPP( int startIdx,
+                                     int endIdx,
+                                     const float inReal[],
+                                     int optInTimePeriod,
+                                     int *outBegIdx,
+                                     int *outNBElement,
+                                     double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 14;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    float *weights = TA_Malloc(sizeof(float)*optInTimePeriod);
+    if(!weights) return TA_ALLOC_ERR;
+    for(int i=0;i<optInTimePeriod;i++)
+        weights[i] = (float)i;
+
+    double SumX = optInTimePeriod * (optInTimePeriod - 1) * 0.5;
+    double SumXSqr = optInTimePeriod * (optInTimePeriod - 1) * (2 * optInTimePeriod - 1) / 6.0;
+    double Divisor = SumX * SumX - optInTimePeriod * SumXSqr;
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        const float *data = &inReal[idx + startIdx - lookbackTotal];
+        Npp32f sumY, sumXY;
+        NppStatus s = nppsSum_32f((Npp32f*)data, optInTimePeriod, &sumY);
+        if( s != NPP_SUCCESS ){ TA_Free(weights); return TA_INTERNAL_ERROR(0); }
+        s = nppsDotProd_32f((Npp32f*)weights, (Npp32f*)data, optInTimePeriod, &sumXY);
+        if( s != NPP_SUCCESS ){ TA_Free(weights); return TA_INTERNAL_ERROR(0); }
+        outReal[idx] = ( optInTimePeriod * sumXY - SumX * sumY) / Divisor;
+    }
+
+    TA_Free(weights);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_LN.c
+++ b/src/ta_func/ta_LN.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_LN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_LN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_log(inReal[i]);

--- a/src/ta_func/ta_LN_NPP.c
+++ b/src/ta_func/ta_LN_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for LN */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_LN_NPP( int startIdx,
+                      int endIdx,
+                      const double inReal[],
+                      int *outBegIdx,
+                      int *outNBElement,
+                      double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsLn_64f((Npp64f*)&inReal[startIdx],
+                             (Npp64f*)outReal,
+                             length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_LN_NPP( int startIdx,
+                        int endIdx,
+                        const float inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsLn_32f((Npp32f*)&inReal[startIdx],
+                             (Npp32f*)outReal,
+                             length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_LOG10.c
+++ b/src/ta_func/ta_LOG10.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_LOG10_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_LOG10_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_log10(inReal[i]);

--- a/src/ta_func/ta_LOG10_NPP.c
+++ b/src/ta_func/ta_LOG10_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for LOG10 */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_LOG10_NPP( int startIdx,
+                         int endIdx,
+                         const double inReal[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsLog10_64f((Npp64f*)&inReal[startIdx],
+                                (Npp64f*)outReal,
+                                length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_LOG10_NPP( int startIdx,
+                           int endIdx,
+                           const float inReal[],
+                           int *outBegIdx,
+                           int *outNBElement,
+                           double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsLog10_32f((Npp32f*)&inReal[startIdx],
+                                (Npp32f*)outReal,
+                                length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_MAX.c
+++ b/src/ta_func/ta_MAX.c
@@ -215,6 +215,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_MAX_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -332,6 +336,10 @@ double outReal[],
 /* Generated */                      double        outReal[] )
 /* Generated */ #endif
 /* Generated */ {
+#ifdef USE_NPP
+   return TA_S_MAX_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    double highest, tmp;
 /* Generated */    int outIdx, nbInitialElementNeeded;
 /* Generated */    int trailingIdx, today, i, highestIdx;

--- a/src/ta_func/ta_MAX_NPP.c
+++ b/src/ta_func/ta_MAX_NPP.c
@@ -1,0 +1,88 @@
+/* NPP accelerated implementation for MAX */
+#include "ta_func.h"
+#include "ta_memory.h"
+#include <npps.h>
+
+TA_RetCode TA_MAX_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int optInTimePeriod,
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp64f val;
+        NppStatus s = nppsMax_64f((Npp64f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &val);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = val;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_MAX_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int optInTimePeriod,
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp32f val;
+        NppStatus s = nppsMax_32f((Npp32f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &val);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = val;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_MIN.c
+++ b/src/ta_func/ta_MIN.c
@@ -215,6 +215,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_MIN_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -332,6 +336,10 @@ double outReal[],
 /* Generated */                      double        outReal[] )
 /* Generated */ #endif
 /* Generated */ {
+#ifdef USE_NPP
+   return TA_S_MIN_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    double lowest, tmp;
 /* Generated */    int outIdx, nbInitialElementNeeded;
 /* Generated */    int trailingIdx, lowestIdx, today, i;

--- a/src/ta_func/ta_MIN_NPP.c
+++ b/src/ta_func/ta_MIN_NPP.c
@@ -1,0 +1,88 @@
+/* NPP accelerated implementation for MIN */
+#include "ta_func.h"
+#include "ta_memory.h"
+#include <npps.h>
+
+TA_RetCode TA_MIN_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int optInTimePeriod,
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp64f val;
+        NppStatus s = nppsMin_64f((Npp64f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &val);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = val;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_MIN_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int optInTimePeriod,
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp32f val;
+        NppStatus s = nppsMin_32f((Npp32f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &val);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = val;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_MULT.c
+++ b/src/ta_func/ta_MULT.c
@@ -190,6 +190,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_MULT_NPP(startIdx, endIdx, inReal0, inReal1,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -268,6 +272,10 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+   return TA_S_MULT_NPP(startIdx, endIdx, inReal0, inReal1,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = inReal0[i]*inReal1[i];

--- a/src/ta_func/ta_MULT_NPP.c
+++ b/src/ta_func/ta_MULT_NPP.c
@@ -1,0 +1,57 @@
+/* NPP accelerated implementation for MULT */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_MULT_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal0[],
+                        const double inReal1[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsMul_64f((Npp64f*)&inReal0[startIdx],
+                              (Npp64f*)&inReal1[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_MULT_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal0[],
+                          const float inReal1[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsMul_32f((Npp32f*)&inReal0[startIdx],
+                              (Npp32f*)&inReal1[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_SIN.c
+++ b/src/ta_func/ta_SIN.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_SIN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_SIN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_sin(inReal[i]);

--- a/src/ta_func/ta_SINH.c
+++ b/src/ta_func/ta_SINH.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_SINH_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_SINH_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_sinh(inReal[i]);

--- a/src/ta_func/ta_SINH_NPP.c
+++ b/src/ta_func/ta_SINH_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for SINH */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_SINH_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSinh_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_SINH_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSinh_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_SIN_NPP.c
+++ b/src/ta_func/ta_SIN_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for SIN */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_SIN_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSin_64f((Npp64f*)&inReal[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_SIN_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSin_32f((Npp32f*)&inReal[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_SMA.c
+++ b/src/ta_func/ta_SMA.c
@@ -207,6 +207,10 @@ double outReal[],
 /* Generated */ #endif /* TA_FUNC_NO_RANGE_CHECK */
 /* Generated */ 
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
+#ifdef USE_NPP
+  return TA_SMA_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                    outBegIdx, outNBElement, outReal);
+#endif
 
   return FUNCTION_CALL(INT_SMA)( startIdx, endIdx,
                                  inReal, optInTimePeriod,
@@ -374,6 +378,10 @@ TA_RetCode TA_PREFIX(INT_SMA)( int    startIdx,
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+  return TA_S_SMA_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                      outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */   return FUNCTION_CALL(INT_SMA)( startIdx, endIdx,
 /* Generated */                                  inReal, optInTimePeriod,
 /* Generated */                                  outBegIdx, outNBElement, outReal );

--- a/src/ta_func/ta_SMA_NPP.c
+++ b/src/ta_func/ta_SMA_NPP.c
@@ -1,0 +1,89 @@
+/* NPP accelerated implementation for SMA */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_SMA_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int optInTimePeriod,
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp64f sumVal;
+        NppStatus s = nppsSum_64f((Npp64f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &sumVal);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = sumVal / optInTimePeriod;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_SMA_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int optInTimePeriod,
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp32f sumVal;
+        NppStatus s = nppsSum_32f((Npp32f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &sumVal);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = sumVal / optInTimePeriod;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_SQRT.c
+++ b/src/ta_func/ta_SQRT.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_SQRT_NPP(startIdx, endIdx, inReal,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,10 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+   return TA_S_SQRT_NPP(startIdx, endIdx, inReal,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_sqrt(inReal[i]);

--- a/src/ta_func/ta_SQRT_NPP.c
+++ b/src/ta_func/ta_SQRT_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for SQRT */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_SQRT_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSqrt_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_SQRT_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSqrt_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_SUB.c
+++ b/src/ta_func/ta_SUB.c
@@ -190,6 +190,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_SUB_NPP(startIdx, endIdx, inReal0, inReal1,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    /* Default return values */
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
@@ -269,6 +273,10 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+   return TA_S_SUB_NPP(startIdx, endIdx, inReal0, inReal1,
+                       outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = inReal0[i]-inReal1[i];

--- a/src/ta_func/ta_SUB_NPP.c
+++ b/src/ta_func/ta_SUB_NPP.c
@@ -1,0 +1,57 @@
+/* NPP accelerated implementation for SUB */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_SUB_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal0[],
+                       const double inReal1[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSub_64f((Npp64f*)&inReal0[startIdx],
+                              (Npp64f*)&inReal1[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_SUB_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal0[],
+                         const float inReal1[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsSub_32f((Npp32f*)&inReal0[startIdx],
+                              (Npp32f*)&inReal1[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_SUM.c
+++ b/src/ta_func/ta_SUM.c
@@ -209,6 +209,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_SUM_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                     outBegIdx, outNBElement, outReal);
+#endif
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -331,6 +335,10 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+#ifdef USE_NPP
+   return TA_S_SUM_NPP(startIdx, endIdx, inReal, optInTimePeriod,
+                      outBegIdx, outNBElement, outReal);
+#endif
 /* Generated */    lookbackTotal = (optInTimePeriod-1);
 /* Generated */    if( startIdx < lookbackTotal )
 /* Generated */       startIdx = lookbackTotal;

--- a/src/ta_func/ta_SUM_NPP.c
+++ b/src/ta_func/ta_SUM_NPP.c
@@ -1,0 +1,89 @@
+/* NPP accelerated implementation for SUM */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_SUM_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int optInTimePeriod,
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp64f sumVal;
+        NppStatus s = nppsSum_64f((Npp64f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &sumVal);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = sumVal;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_SUM_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int optInTimePeriod,
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    if( optInTimePeriod == TA_INTEGER_DEFAULT )
+        optInTimePeriod = 30;
+    else if( optInTimePeriod < 2 || optInTimePeriod > 100000 )
+        return TA_BAD_PARAM;
+
+    int lookbackTotal = optInTimePeriod - 1;
+    if( startIdx < lookbackTotal )
+        startIdx = lookbackTotal;
+    if( startIdx > endIdx ) {
+        *outBegIdx = 0;
+        *outNBElement = 0;
+        return TA_SUCCESS;
+    }
+
+    int length = endIdx - startIdx + 1;
+    for( int idx = 0; idx < length; ++idx ) {
+        Npp32f sumVal;
+        NppStatus s = nppsSum_32f((Npp32f*)&inReal[idx + startIdx - lookbackTotal],
+                                  optInTimePeriod,
+                                  &sumVal);
+        if( s != NPP_SUCCESS )
+            return TA_INTERNAL_ERROR(0);
+        outReal[idx] = sumVal;
+    }
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_TAN.c
+++ b/src/ta_func/ta_TAN.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_TAN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
       outReal[outIdx] = std_tan(inReal[i]);
@@ -256,6 +260,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_TAN_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_tan(inReal[i]);

--- a/src/ta_func/ta_TANH.c
+++ b/src/ta_func/ta_TANH.c
@@ -184,6 +184,10 @@ double outReal[],
 /**** END GENCODE SECTION 4 - DO NOT DELETE THIS LINE ****/
 
    /* Insert TA function code here. */
+#ifdef USE_NPP
+   return TA_TANH_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
 
    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
    {
@@ -257,6 +261,11 @@ double outReal[],
 /* Generated */     #endif 
 /* Generated */  #endif
 /* Generated */  #endif 
+/* Generated */    #ifdef USE_NPP
+   return TA_S_TANH_NPP(startIdx, endIdx, inReal, outBegIdx, outNBElement, outReal);
+#endif
+
+
 /* Generated */    for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */    {
 /* Generated */       outReal[outIdx] = std_tanh(inReal[i]);

--- a/src/ta_func/ta_TANH_NPP.c
+++ b/src/ta_func/ta_TANH_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for TANH */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_TANH_NPP( int startIdx,
+                        int endIdx,
+                        const double inReal[],
+                        int *outBegIdx,
+                        int *outNBElement,
+                        double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsTanh_64f((Npp64f*)&inReal[startIdx],
+                               (Npp64f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_TANH_NPP( int startIdx,
+                          int endIdx,
+                          const float inReal[],
+                          int *outBegIdx,
+                          int *outNBElement,
+                          double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsTanh_32f((Npp32f*)&inReal[startIdx],
+                               (Npp32f*)outReal,
+                               length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}

--- a/src/ta_func/ta_TAN_NPP.c
+++ b/src/ta_func/ta_TAN_NPP.c
@@ -1,0 +1,53 @@
+/* NPP accelerated implementation for TAN */
+#include "ta_func.h"
+#include "ta_memory.h"
+
+#include <npps.h>
+
+TA_RetCode TA_TAN_NPP( int startIdx,
+                       int endIdx,
+                       const double inReal[],
+                       int *outBegIdx,
+                       int *outNBElement,
+                       double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsTan_64f((Npp64f*)&inReal[startIdx],
+                              (Npp64f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}
+
+TA_RetCode TA_S_TAN_NPP( int startIdx,
+                         int endIdx,
+                         const float inReal[],
+                         int *outBegIdx,
+                         int *outNBElement,
+                         double outReal[] )
+{
+    int length;
+    if( startIdx < 0 )
+        return TA_OUT_OF_RANGE_START_INDEX;
+    if( endIdx < startIdx )
+        return TA_OUT_OF_RANGE_END_INDEX;
+
+    length = endIdx - startIdx + 1;
+    NppStatus s = nppsTan_32f((Npp32f*)&inReal[startIdx],
+                              (Npp32f*)outReal,
+                              length);
+    if( s != NPP_SUCCESS )
+        return TA_INTERNAL_ERROR(0);
+    *outBegIdx = startIdx;
+    *outNBElement = length;
+    return TA_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- remove duplicate NPP blocks in `ta_ACOS.c`
- accelerate `AVGPRICE` with new `ta_AVGPRICE_NPP.c`
- wire up new NPP functions in headers and build files
- call `AVGPRICE_NPP` when `USE_NPP` is enabled

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68463220de88832799c084762620c8e5